### PR TITLE
V1 ipfs improvements

### DIFF
--- a/v1/@types/hyper-sdk.d.ts
+++ b/v1/@types/hyper-sdk.d.ts
@@ -2,6 +2,7 @@ declare module 'hyper-sdk' {
   export class Hyperdrive {
     once (evt: string, cb: () => void): void
     get url (): string
+    get id (): string
     close (): Promise<void>
   }
 

--- a/v1/@types/mirror-drive.d.ts
+++ b/v1/@types/mirror-drive.d.ts
@@ -7,6 +7,6 @@ declare module 'mirror-drive' {
     constructor (drive1: DriveLike, drive2: DriveLike)
     get count (): number
     done (): Promise<void>
-    [Symbol.asyncIterator](): AsyncIterator<{op: string, key: string}>
+    [Symbol.asyncIterator] (): AsyncIterator<{ op: string, key: string }>
   }
 }

--- a/v1/@types/mirror-drive.d.ts
+++ b/v1/@types/mirror-drive.d.ts
@@ -7,5 +7,6 @@ declare module 'mirror-drive' {
     constructor (drive1: DriveLike, drive2: DriveLike)
     get count (): number
     done (): Promise<void>
+    [Symbol.asyncIterator](): AsyncIterator<{op: string, key: string}>
   }
 }

--- a/v1/dns/index.ts
+++ b/v1/dns/index.ts
@@ -2,12 +2,12 @@ import dns2 from 'dns2'
 import { FastifyBaseLogger } from 'fastify'
 import { SiteConfigStore } from '../config/sites.js'
 
-function protocolToMultiformat(link: string): string {
-  const [protocol, path] = link.split("://")
+function protocolToMultiformat (link: string): string {
+  const [protocol, path] = link.split('://')
   return `/${protocol}/${path}`
 }
 
-export async function initDnsServer(port: number, store: SiteConfigStore, logger: FastifyBaseLogger): Promise<ReturnType<typeof dns2.createServer>> {
+export async function initDnsServer (port: number, store: SiteConfigStore, logger: FastifyBaseLogger): Promise<ReturnType<typeof dns2.createServer>> {
   const server = dns2.createServer({
     udp: true,
     handle: (request, send, rinfo) => {

--- a/v1/package.json
+++ b/v1/package.json
@@ -13,7 +13,7 @@
     "dev": "ts-node-esm index.ts | pino-pretty -c -t",
     "watch": "nodemon --watch './**/*.ts' --exec 'node --experimental-specifier-resolution=node --loader ts-node/esm' index.ts | pino-pretty -c -t",
     "start": "node build/index.js",
-    "test": "ava --timeout=2m"
+    "test": "ava --timeout=5m"
   },
   "repository": {
     "type": "git",
@@ -61,7 +61,6 @@
     "hyper-sdk": "^4.2.1",
     "ipfs-core": "^0.18.0",
     "ipfs-http-client": "^60.0.0",
-    "ipfs-mfs-sync": "^1.1.0",
     "ipfsd-ctl": "^13.0.0",
     "is-valid-hostname": "^1.0.2",
     "level": "^8.0.0",

--- a/v1/package.json
+++ b/v1/package.json
@@ -61,7 +61,7 @@
     "hyper-sdk": "^4.2.1",
     "ipfs-core": "^0.18.0",
     "ipfs-http-client": "^60.0.0",
-    "ipfs-mfs-sync": "^1.0.4",
+    "ipfs-mfs-sync": "^1.1.0",
     "ipfsd-ctl": "^13.0.0",
     "is-valid-hostname": "^1.0.2",
     "level": "^8.0.0",

--- a/v1/protocols/hyper.ts
+++ b/v1/protocols/hyper.ts
@@ -53,7 +53,6 @@ export class HyperProtocol implements Protocol<Static<typeof HyperProtocolFields
 
     const mirror = fs.mirror(drive)
 
-    // TODO: Should we log the changes somewhere like IPFS?
     for await (const change of mirror) {
       ctx?.logger.debug(`[hyper] ${change.op}: ${change.key}`)
     }

--- a/v1/protocols/hyper.ts
+++ b/v1/protocols/hyper.ts
@@ -54,12 +54,14 @@ export class HyperProtocol implements Protocol<Static<typeof HyperProtocolFields
     const mirror = fs.mirror(drive)
 
     // TODO: Should we log the changes somewhere like IPFS?
-    await mirror.done()
+    for await (const change of mirror) {
+      ctx?.logger.debug(`[hyper] ${change.op}: ${change.key}`)
+    }
 
     const raw = drive.url
     const link = raw
-    // TODO: Pass in the gateway URL in the config first
-    const gateway = 'oops'
+    // TODO: Pass in gateway from config
+    const gateway = 'https://hyper.hypha.coop/hyper/${drive.id}/'
 
     ctx?.logger.info(`[hyper] Published: ${link}`)
 

--- a/v1/protocols/hyper.ts
+++ b/v1/protocols/hyper.ts
@@ -61,7 +61,7 @@ export class HyperProtocol implements Protocol<Static<typeof HyperProtocolFields
     const raw = drive.url
     const link = raw
     // TODO: Pass in gateway from config
-    const gateway = 'https://hyper.hypha.coop/hyper/${drive.id}/'
+    const gateway = `https://hyper.hypha.coop/hyper/${drive.id}/`
 
     ctx?.logger.info(`[hyper] Published: ${link}`)
 

--- a/v1/protocols/ipfs.ts
+++ b/v1/protocols/ipfs.ts
@@ -121,6 +121,8 @@ export class IPFSProtocol implements Protocol<Static<typeof IPFSProtocolFields>>
       throw new Error('IPFS must be initialized using load() before calling sync()')
     }
 
+    // By default, inline empty directory CID
+    let toPublish = '/ipfs/bafyaabakaieac/'
     let lastEntry = null
 
     const glob = IPFS.globSource(folderPath, '**/*')
@@ -135,11 +137,9 @@ export class IPFSProtocol implements Protocol<Static<typeof IPFSProtocolFields>>
       lastEntry = file
     }
 
-    if (lastEntry == null) {
-      throw new Error('No files found')
+    if (lastEntry !== null) {
+      toPublish = `/ipfs/${lastEntry.cid.toString()}/`
     }
-
-    const ipfsPath = `/ipfs/${lastEntry.cid.toString()}/`
 
     try {
       await this.ipfs.files.rm(mfsLocation, {
@@ -151,7 +151,7 @@ export class IPFSProtocol implements Protocol<Static<typeof IPFSProtocolFields>>
       }
     }
 
-    await this.ipfs.files.cp(ipfsPath, mfsLocation, {
+    await this.ipfs.files.cp(toPublish, mfsLocation, {
       cidVersion: 1,
       parents: true,
       flush: true

--- a/v1/protocols/ipfs.ts
+++ b/v1/protocols/ipfs.ts
@@ -138,7 +138,7 @@ export class IPFSProtocol implements Protocol<Static<typeof IPFSProtocolFields>>
 
     // Sync local disk files to MFS
     for await (const change of this.mfsSync.fromFSToMFS(folderPath, mfsLocation, mfsSyncOptions)) {
-      ctx?.logger.debug(change)
+      ctx?.logger.debug(`[ipfs] ${change.op}: ${change.path}`)
     }
 
     // Publish site and return meta

--- a/v1/protocols/ipfs.ts
+++ b/v1/protocols/ipfs.ts
@@ -121,13 +121,6 @@ export class IPFSProtocol implements Protocol<Static<typeof IPFSProtocolFields>>
       throw new Error('IPFS must be initialized using load() before calling sync()')
     }
 
-    // Make a folder in MFS
-    await this.ipfs.files.mkdir(mfsLocation, {
-      parents: true,
-      flush: true,
-      cidVersion: 1
-    })
-
     let lastEntry = null
 
     const glob = IPFS.globSource(folderPath, '**/*')
@@ -148,7 +141,15 @@ export class IPFSProtocol implements Protocol<Static<typeof IPFSProtocolFields>>
 
     const ipfsPath = `/ipfs/${lastEntry.cid.toString()}/`
 
-    await this.ipfs.files.cp(ipfsPath, mfsLocation)
+    await this.ipfs.files.rm(mfsLocation, {
+      recursive: true
+    })
+
+    await this.ipfs.files.cp(ipfsPath, mfsLocation, {
+      cidVersion: 1,
+      parents: true,
+      flush: true
+    })
 
     // Publish site and return meta
     const { publishKey, cid } = await this.publishSite(id, ctx)

--- a/v1/protocols/ipfs.ts
+++ b/v1/protocols/ipfs.ts
@@ -141,9 +141,15 @@ export class IPFSProtocol implements Protocol<Static<typeof IPFSProtocolFields>>
 
     const ipfsPath = `/ipfs/${lastEntry.cid.toString()}/`
 
-    await this.ipfs.files.rm(mfsLocation, {
-      recursive: true
-    })
+    try {
+      await this.ipfs.files.rm(mfsLocation, {
+        recursive: true
+      })
+    } catch (e) {
+      if (!(e instanceof Error) || !e.message.includes('file does not exist')) {
+        throw e
+      }
+    }
 
     await this.ipfs.files.cp(ipfsPath, mfsLocation, {
       cidVersion: 1,


### PR DESCRIPTION
Removed the mfs-sync code since MFS is super slow. Now I use addAll and then put the root CID into MFS which seems to be a lot faster.

Initial publishes take like 2 minutes, but subsequent ones are a lot faster at just 13 seconds. I think this is due to the DHT needing time to bootstrap it's kademlia buckets.

This should fix #39 

Not sure what's up with the diff, might need to rebase off of v1-staging again.