### PR TITLE
V1 ipfs improvements 2

### DIFF
--- a/ansible/roles/distributed_press/tasks/main.yml
+++ b/ansible/roles/distributed_press/tasks/main.yml
@@ -41,15 +41,24 @@
     cd {{distributed_press_source}}
     npm ci
 
-- name: Nuke cache and protocol config
-  become: yes
-  become_user: "{{distributed_press_user}}"
-  shell: |
-    cd {{distributed_press_source}}
-    npm run nuke
+#- name: Nuke cache and protocol config
+#  become: yes
+#  become_user: "{{distributed_press_user}}"
+#  shell: |
+#    cd {{distributed_press_source}}
+#    npm run nuke
 
-- name: Enable Node to bind to port 53 for DNS
+- name: "Enable Node to bind to port 53 for DNS"
   shell: setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/node
+
+- name: "Enable DNS traffic through firewall"
+  shell: "iptables -A INPUT -p udp -m udp --dport 53 -j ACCEPT"
+
+- name: "Enable libp2p udp traffic through firewall"
+  shell: "iptables -A INPUT -p udp -m udp --dport 7976 -j ACCEPT"
+
+- name: "Enable libp2p tcp traffic through firewall"
+  shell: "iptables -A INPUT -p tcp -m tcp --dport 7976 -j ACCEPT"
 
 #- name: Build service
 #  become: yes

--- a/api/index.ts
+++ b/api/index.ts
@@ -81,7 +81,7 @@ async function apiBuilder (cfg: APIConfig): Promise<FastifyTypebox> {
     server.log.info(`Presyncing site: ${siteId}`)
     const fp = store.fs.getPath(siteId)
     await store.sites.sync(siteId, fp, { logger: server.log })
-  })
+  }))
 
   // handle cleanup on shutdown
   server.addHook('onClose', async server => {

--- a/api/index.ts
+++ b/api/index.ts
@@ -76,11 +76,12 @@ async function apiBuilder (cfg: APIConfig): Promise<FastifyTypebox> {
   await server.register(multipart)
 
   // pre-sync all sites
-  for (const siteId of await store.sites.keys()) {
+  const allSites = await store.sites.keys()
+  await Promise.all(allSites.map(async (siteId) => {
     server.log.info(`Presyncing site: ${siteId}`)
     const fp = store.fs.getPath(siteId)
     await store.sites.sync(siteId, fp, { logger: server.log })
-  }
+  })
 
   // handle cleanup on shutdown
   server.addHook('onClose', async server => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,12 +27,11 @@
         "fastify-plugin": "^4.4.0",
         "fs": "0.0.1-security",
         "get-port": "^6.1.2",
-        "go-ipfs": "^0.17.0",
+        "go-ipfs": "^0.18.1",
         "gunzip-maybe": "^1.4.2",
         "hyper-sdk": "^4.2.1",
         "ipfs-core": "^0.18.0",
         "ipfs-http-client": "^60.0.0",
-        "ipfs-mfs-sync": "^1.0.4",
         "ipfsd-ctl": "^13.0.0",
         "is-valid-hostname": "^1.0.2",
         "level": "^8.0.0",
@@ -6407,9 +6406,9 @@
       }
     },
     "node_modules/go-ipfs": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.17.0.tgz",
-      "integrity": "sha512-D3IUkTzLrnvgOs38HNqE8TK+sP7FDhdygVEzedsgwY1UIxPwxPFYuxRrdOcDHGQiwxHRORUHNudy2mEdxvHKkQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.18.1.tgz",
+      "integrity": "sha512-hXfjQRqet/H8mTSQVKiuTSMrvjv8cAGQMHbr12DHAHGsSMS9IuGCOntkVEhnNOnmP/WXcrxRVxLu6xz/mPLlZg==",
       "hasInstallScript": true,
       "dependencies": {
         "cachedir": "^2.3.0",
@@ -7209,14 +7208,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-mfs-sync": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-mfs-sync/-/ipfs-mfs-sync-1.0.4.tgz",
-      "integrity": "sha512-KDjZQDAIjlO7ZAHrFNIX9RHE10NZUB9NAgj+s9t+iWgRdbLORtJrze+zjGH9QiR34RbtKQLmti+WlrlVUUUSvQ==",
-      "dependencies": {
-        "streamx": "^2.13.2"
       }
     },
     "node_modules/ipfs-repo": {
@@ -17839,9 +17830,9 @@
       }
     },
     "go-ipfs": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.17.0.tgz",
-      "integrity": "sha512-D3IUkTzLrnvgOs38HNqE8TK+sP7FDhdygVEzedsgwY1UIxPwxPFYuxRrdOcDHGQiwxHRORUHNudy2mEdxvHKkQ==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.18.1.tgz",
+      "integrity": "sha512-hXfjQRqet/H8mTSQVKiuTSMrvjv8cAGQMHbr12DHAHGsSMS9IuGCOntkVEhnNOnmP/WXcrxRVxLu6xz/mPLlZg==",
       "requires": {
         "cachedir": "^2.3.0",
         "got": "^11.7.0",
@@ -18483,14 +18474,6 @@
         "parse-duration": "^1.0.0",
         "stream-to-it": "^0.2.2",
         "uint8arrays": "^4.0.2"
-      }
-    },
-    "ipfs-mfs-sync": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ipfs-mfs-sync/-/ipfs-mfs-sync-1.0.4.tgz",
-      "integrity": "sha512-KDjZQDAIjlO7ZAHrFNIX9RHE10NZUB9NAgj+s9t+iWgRdbLORtJrze+zjGH9QiR34RbtKQLmti+WlrlVUUUSvQ==",
-      "requires": {
-        "streamx": "^2.13.2"
       }
     },
     "ipfs-repo": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "get-port": "^6.1.2",
         "go-ipfs": "^0.18.1",
         "gunzip-maybe": "^1.4.2",
-        "hyper-sdk": "^4.2.1",
+        "hyper-sdk": "^4.2.3",
         "ipfs-core": "^0.18.0",
         "ipfs-http-client": "^60.0.0",
         "ipfsd-ctl": "^13.0.0",
@@ -6706,9 +6706,9 @@
       }
     },
     "node_modules/hyper-sdk": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hyper-sdk/-/hyper-sdk-4.2.1.tgz",
-      "integrity": "sha512-NSHUZeJJKImlbgmbyJT2hR7WaM67ZuYyBYjz3TKdXDjJj/x7Hxlt7t4CloB5yVtTSiBQAqFl2yjB1fOGbdYWLg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/hyper-sdk/-/hyper-sdk-4.2.3.tgz",
+      "integrity": "sha512-aqrn9/UJXm2q4Sj9H7yoQYqhRpCm7lycVqRmJlvWmUjWOXu1Ii9gnNDQ620GrWwA1s20e9qZR6KTSrGUPFsWHA==",
       "dependencies": {
         "b4a": "^1.6.1",
         "corestore": "^6.4.2",
@@ -18056,9 +18056,9 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
     },
     "hyper-sdk": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hyper-sdk/-/hyper-sdk-4.2.1.tgz",
-      "integrity": "sha512-NSHUZeJJKImlbgmbyJT2hR7WaM67ZuYyBYjz3TKdXDjJj/x7Hxlt7t4CloB5yVtTSiBQAqFl2yjB1fOGbdYWLg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/hyper-sdk/-/hyper-sdk-4.2.3.tgz",
+      "integrity": "sha512-aqrn9/UJXm2q4Sj9H7yoQYqhRpCm7lycVqRmJlvWmUjWOXu1Ii9gnNDQ620GrWwA1s20e9qZR6KTSrGUPFsWHA==",
       "requires": {
         "b4a": "^1.6.1",
         "corestore": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "fastify-plugin": "^4.4.0",
     "fs": "0.0.1-security",
     "get-port": "^6.1.2",
-    "go-ipfs": "^0.17.0",
+    "go-ipfs": "^0.18.1",
     "gunzip-maybe": "^1.4.2",
     "hyper-sdk": "^4.2.1",
     "ipfs-core": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "get-port": "^6.1.2",
     "go-ipfs": "^0.18.1",
     "gunzip-maybe": "^1.4.2",
-    "hyper-sdk": "^4.2.1",
+    "hyper-sdk": "^4.2.3",
     "ipfs-core": "^0.18.0",
     "ipfs-http-client": "^60.0.0",
     "ipfsd-ctl": "^13.0.0",

--- a/protocols/ipfs.ts
+++ b/protocols/ipfs.ts
@@ -60,6 +60,7 @@ export class IPFSProtocol implements Protocol<Static<typeof IPFSProtocolFields>>
             Experimental: {
               AcceleratedDHTClient: true
             },
+            Gateway: null,
             Addresses: {
               API: `/ip4/127.0.0.1/tcp/${apiPort}`,
               Gateway: null,


### PR DESCRIPTION
- Updates go-ipfs
- Adds more flags to config to improve performance
- Add iptables to ansible deploy (todo need to persist them)
- Catch common Kubo shutdown errors where lockfiles aren't cleared and attempt to clear them
- Fix up gateway URLs for hyperdrives