### PR TITLE
Use concurrency queue for initial site sync on boot

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -80,6 +80,7 @@ async function apiBuilder (cfg: APIConfig): Promise<FastifyTypebox> {
   await registerAuth(cfg, server, store)
   await server.register(multipart)
 
+  /*
   // pre-sync all sites
   const allSites = await store.sites.keys()
   await pMap(allSites, async (siteId) => {
@@ -88,6 +89,7 @@ async function apiBuilder (cfg: APIConfig): Promise<FastifyTypebox> {
     await store.sites.sync(siteId, fp, { logger: server.log })
     server.log.info(`Finished presync: ${siteId}`)
   }, { concurrency: 1 })
+  */
 
   // handle cleanup on shutdown
   server.addHook('onClose', async server => {

--- a/api/index.ts
+++ b/api/index.ts
@@ -87,7 +87,7 @@ async function apiBuilder (cfg: APIConfig): Promise<FastifyTypebox> {
     const fp = store.fs.getPath(siteId)
     await store.sites.sync(siteId, fp, { logger: server.log })
     server.log.info(`Finished presync: ${siteId}`)
-  }, { concurrency: 2 })
+  }, { concurrency: 1 })
 
   // handle cleanup on shutdown
   server.addHook('onClose', async server => {

--- a/api/index.ts
+++ b/api/index.ts
@@ -86,6 +86,7 @@ async function apiBuilder (cfg: APIConfig): Promise<FastifyTypebox> {
     server.log.info(`Presyncing site: ${siteId}`)
     const fp = store.fs.getPath(siteId)
     await store.sites.sync(siteId, fp, { logger: server.log })
+    server.log.info(`Finished presync: ${siteId}`)
   }, { concurrency: 2 })
 
   // handle cleanup on shutdown

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "localdrive": "^1.4.0",
         "make-dir": "^3.1.0",
         "nanoid": "^4.0.0",
+        "p-map": "^6.0.0",
         "prom-client": "^14.1.0",
         "tar-fs": "^2.1.1",
         "yargs": "^17.6.2"
@@ -3475,6 +3476,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ava/node_modules/p-map": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
+      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ava/node_modules/path-exists": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -4699,6 +4715,21 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
       "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
       "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/del/node_modules/p-map": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
+      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^4.0.0"
+      },
       "engines": {
         "node": ">=12"
       },
@@ -9763,15 +9794,11 @@
       }
     },
     "node_modules/p-map": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
-      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
-      "dev": true,
-      "dependencies": {
-        "aggregate-error": "^4.0.0"
-      },
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
+      "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==",
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15608,6 +15635,15 @@
             "p-limit": "^4.0.0"
           }
         },
+        "p-map": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
+          "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^4.0.0"
+          }
+        },
         "path-exists": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -16547,6 +16583,15 @@
           "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
           "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
           "dev": true
+        },
+        "p-map": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
+          "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
+          "dev": true,
+          "requires": {
+            "aggregate-error": "^4.0.0"
+          }
         },
         "rimraf": {
           "version": "3.0.2",
@@ -20353,13 +20398,9 @@
       }
     },
     "p-map": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
-      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
-      "dev": true,
-      "requires": {
-        "aggregate-error": "^4.0.0"
-      }
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
+      "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw=="
     },
     "p-queue": {
       "version": "7.3.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "localdrive": "^1.4.0",
     "make-dir": "^3.1.0",
     "nanoid": "^4.0.0",
+    "p-map": "^6.0.0",
     "prom-client": "^14.1.0",
     "tar-fs": "^2.1.1",
     "yargs": "^17.6.2"


### PR DESCRIPTION
Seems we've gotten to the scale where the initial site sync on boot is causing IPFS to freeze up. I'm going to reduce the concurrency to two sites at a time which should increase the initial load, but it might help avoid the freezing we're seeing now.

We can slowly turn this up to see how it goes.