### PR TITLE
ansible roles for social inbox

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -54,3 +54,17 @@ cd ~/api.distributed.press
 systemctl status distributed.press
 journalctl -fu distributed.press
 ```
+
+## Social Inbox
+
+You can deploy an instance of the [Distributed Press Social Inbox](https://github.com/hyphacoop/social.distributed.press) along side the press by toggling the `social_inbox_enabled` flag.
+
+```yaml
+---
+all:
+  vars:
+    social_inbox_enabled: true
+    social_inbox_domain: "social.example.com"
+    social_inbox_admins:
+      - "@username@yourdomain.com"
+```

--- a/ansible/roles/distributed_press/defaults/main.yml
+++ b/ansible/roles/distributed_press/defaults/main.yml
@@ -22,3 +22,19 @@ distributed_press_letsencrypt_email: "example@example.com"
 
 # These will be used to be served over nginx along with letsencrypt certs
 distributed_press_served_sites: []
+
+# Prefix with social_inbox_
+# These vars are for adding the distributed press social inbox
+social_inbox_enabled: false
+social_inbox_user: "social"
+social_inbox_home: "/home/{{social_inbox_user}}"
+social_inbox_service_name: "social.distributed.press"
+social_inbox_data: "{{social_inbox_home}}/.local/share/social.distributed.press-nodejs"
+
+social_inbox_domain: "social.example.com"
+social_inbox_host: "localhost"
+social_inbox_port: 7625 # SOCL on a phone number pad
+
+social_inbox_git_repo: "https://github.com/hyphacoop/social.distributed.press.git"
+social_inbox_git_branch: "initial"
+social_inbox_source: "{{social_inbox_home}}/social.distributed.press"

--- a/ansible/roles/distributed_press/defaults/main.yml
+++ b/ansible/roles/distributed_press/defaults/main.yml
@@ -38,3 +38,7 @@ social_inbox_port: 7625 # SOCL on a phone number pad
 social_inbox_git_repo: "https://github.com/hyphacoop/social.distributed.press.git"
 social_inbox_git_branch: "initial"
 social_inbox_source: "{{social_inbox_home}}/social.distributed.press"
+## Set this to false to skip importing it
+social_inbox_blocklist: "https://github.com/gardenfence/blocklist/raw/main/gardenfence-mastodon.csv"
+## Make sure to set this if you want to be able to administrate things!
+social_inbox_admins: []

--- a/ansible/roles/distributed_press/tasks/main.yml
+++ b/ansible/roles/distributed_press/tasks/main.yml
@@ -130,6 +130,28 @@
     cd {{social_inbox_source}}
     npm ci
 
+- name: Import blocklist for social inbox
+  when:
+    - social_inbox_enabled
+    - social_inbox_blocklist
+  become: yes
+  become_user: "{{social_inbox_user}}"
+  shell: |
+    cd {{social_inbox_source}}
+    npm run import-blocklist -- --list {{social_inbox_blocklist}}
+
+
+- name: Import admin kist for social inbox
+  when:
+    -  social_inbox_enabled
+    - social_inbox_admins is iterable
+    - social_inbox_admins | length > 0
+  become: yes
+  become_user: "{{social_inbox_user}}"
+  shell: |
+    cd {{social_inbox_source}}
+    npm run import-admins -- {{ social_inbox_admins | map('regex_replace', '^', '--list ') | join(' ') }}
+
 - name: "Run social.distributed.press service"
   when: social_inbox_enabled
   systemd:

--- a/ansible/roles/distributed_press/tasks/main.yml
+++ b/ansible/roles/distributed_press/tasks/main.yml
@@ -9,6 +9,16 @@
     shell: /bin/bash
     comment: User for the distributed.press API server
 
+- name: Ensure user exists for DP service
+  when: social_inbox_enabled
+  user:
+    name: "{{social_inbox_user}}"
+    append: true
+    # TODO: is this needed?
+    groups: adm
+    shell: /bin/bash
+    comment: User for the social.distributed.press API server
+
 - name: "Ensure nginx can access site data"
   user:
     name: '{{distributed_press_user}}'
@@ -88,6 +98,46 @@
     enabled: true
     name: "{{distributed_press_service_name}}"
 
+
+- name: Add social.distributed.press systemd service
+  when: social_inbox_enabled
+  template:
+    src: social.distributed.press.service.j2
+    dest: "/etc/systemd/system/{{social_inbox_service_name}}.service"
+
+- name: "Stop social.distributed.press service to recompile"
+  when: social_inbox_enabled
+  systemd:
+    state: stopped
+    name: "{{social_inbox_service_name}}"
+
+- name: Clone or update Social.DP codebase
+  when: social_inbox_enabled
+  become: yes
+  become_user: "{{social_inbox_user}}"
+  git:
+    repo: "{{social_inbox_git_repo}}"
+    version: "{{social_inbox_git_branch}}"
+    dest: "{{social_inbox_source}}"
+    clone: yes
+    update: yes
+
+- name: Install NPM Dependencies for social inbox
+  when: social_inbox_enabled
+  become: yes
+  become_user: "{{social_inbox_user}}"
+  shell: |
+    cd {{social_inbox_source}}
+    npm ci
+
+- name: "Run social.distributed.press service"
+  when: social_inbox_enabled
+  systemd:
+    daemon_reload: true
+    state: restarted
+    enabled: true
+    name: "{{social_inbox_service_name}}"
+
 - name: "Install NGINX/Certbot"
   apt:
     pkg:
@@ -108,7 +158,7 @@
     name: nginx
 
 - name: "Register certbot certificate"
-  shell: "certbot --nginx --non-interactive -d {{distributed_press_domain}} {{ distributed_press_served_sites | map('regex_replace', '^', '-d ') | join(' ') }} --expand --agree-tos --no-eff-email --email {{distributed_press_letsencrypt_email}}"
+  shell: "certbot --nginx --non-interactive -d {{distributed_press_domain}} {{ distributed_press_served_sites | map('regex_replace', '^', '-d ') | join(' ') }} {% if (social_inbox_enabled) %} -d {{ social_inbox_domain }} {% endif %}--expand --agree-tos --no-eff-email --email {{distributed_press_letsencrypt_email}}"
 
 - name: "Copy over default site config"
   template:
@@ -119,6 +169,12 @@
   template:
     src: nginx-site.j2
     dest: "/etc/nginx/sites-enabled/{{distributed_press_domain}}"
+
+- name: "Copy over social inbox site config"
+  when: social_inbox_enabled
+  template:
+    src: nginx-social-site.j2
+    dest: "/etc/nginx/sites-enabled/{{social_inbox_domain}}"
 
 - name: "Copy over static site configs"
   template:

--- a/ansible/roles/distributed_press/templates/distributed.press.service.j2
+++ b/ansible/roles/distributed_press/templates/distributed.press.service.j2
@@ -2,7 +2,7 @@
 Description=Distributed Press API Server
 After=network-online.target
 [Service]
-Environment="DEBUG=*"
+# Environment="DEBUG=*"
 WorkingDirectory={{distributed_press_source}}
 User={{distributed_press_user}}
 ExecStart=npx ts-node-esm index.ts --port {{distributed_press_port}} --host {{distributed_press_host}} --ipfs-provider {{distributed_press_ipfs_provider}}

--- a/ansible/roles/distributed_press/templates/nginx-social-site.j2
+++ b/ansible/roles/distributed_press/templates/nginx-social-site.j2
@@ -1,0 +1,54 @@
+server {
+  server_name {{social_inbox_domain}};
+
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  add_header 'X-Frame-Options' 'ALLOW-FROM *';
+  add_header 'Access-Control-Allow-Origin' '*';
+  add_header 'Access-Control-Allow-Credentials' 'true';
+  add_header 'Access-Control-Allow-Methods' '*';
+  add_header 'Access-Control-Allow-Headers' '*';
+
+  # Wait up to 8 mins for stuff to happen
+  # This is mostly important for publishing
+  client_body_timeout 480;
+  client_header_timeout 240;
+  proxy_read_timeout 1200;
+  keepalive_timeout 60;
+  # Disable a bunch of nginx buffering
+  # Should speed up uploads
+  client_max_body_size 0;
+  proxy_http_version 1.1;
+  proxy_request_buffering off;
+  proxy_buffering off;
+  proxy_max_temp_file_size 0;
+
+  location / {
+    client_max_body_size 0;
+
+    proxy_pass http://{{social_inbox_host}}:{{social_inbox_port}};
+    proxy_set_header    Host            $host;
+    proxy_set_header    X-Real-IP       $remote_addr;
+    proxy_set_header    X-Forwarded-for $remote_addr;
+    port_in_redirect    off;
+    proxy_http_version  1.1;
+    proxy_set_header    Upgrade         $http_upgrade;
+    proxy_set_header    Connection      "Upgrade";
+  }
+
+  listen [::]:443 ssl; # managed by Certbot
+  listen 443 ssl; # managed by Certbot
+  ssl_certificate /etc/letsencrypt/live/{{distributed_press_domain}}/fullchain.pem; # managed by Certbot
+  ssl_certificate_key /etc/letsencrypt/live/{{distributed_press_domain}}/privkey.pem; # managed by Certbot
+  include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+  ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+
+server {
+  server_name {{social_inbox_domain}};
+
+  listen 80;
+  listen [::]:80;
+
+  return  301 https://{{social_inbox_domain}}$request_uri;
+}

--- a/ansible/roles/distributed_press/templates/social.distributed.press.service.j2
+++ b/ansible/roles/distributed_press/templates/social.distributed.press.service.j2
@@ -5,7 +5,7 @@ After=network-online.target
 # Environment="DEBUG=*"
 WorkingDirectory={{social_inbox_source}}
 User={{social_inbox_user}}
-ExecStart=npx ts-node-esm index.ts --port {{social_inbox_port}} --host {{social_inbox_host}} --publicURL https://{{social_inbox_domain}}
+ExecStart=npx ts-node-esm src/server/index.ts --port {{social_inbox_port}} --host {{social_inbox_host}} --publicURL https://{{social_inbox_domain}}
 Restart=always
 RestartSec=3
 LimitNOFILE=4096

--- a/ansible/roles/distributed_press/templates/social.distributed.press.service.j2
+++ b/ansible/roles/distributed_press/templates/social.distributed.press.service.j2
@@ -2,7 +2,7 @@
 Description=Distributed Press Social Inbox Server
 After=network-online.target
 [Service]
-Environment="DEBUG=*"
+# Environment="DEBUG=*"
 WorkingDirectory={{social_inbox_source}}
 User={{social_inbox_user}}
 ExecStart=npx ts-node-esm index.ts --port {{social_inbox_port}} --host {{social_inbox_host}}

--- a/ansible/roles/distributed_press/templates/social.distributed.press.service.j2
+++ b/ansible/roles/distributed_press/templates/social.distributed.press.service.j2
@@ -5,7 +5,7 @@ After=network-online.target
 # Environment="DEBUG=*"
 WorkingDirectory={{social_inbox_source}}
 User={{social_inbox_user}}
-ExecStart=npx ts-node-esm src/server/index.ts --port {{social_inbox_port}} --host {{social_inbox_host}} --publicURL https://{{social_inbox_domain}}
+ExecStart=npx ts-node-esm src/bin.ts run --port {{social_inbox_port}} --host {{social_inbox_host}} --publicURL https://{{social_inbox_domain}}
 Restart=always
 RestartSec=3
 LimitNOFILE=4096

--- a/ansible/roles/distributed_press/templates/social.distributed.press.service.j2
+++ b/ansible/roles/distributed_press/templates/social.distributed.press.service.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Distributed Press Social Inbox Server
+After=network-online.target
+[Service]
+Environment="DEBUG=*"
+WorkingDirectory={{social_inbox_source}}
+User={{social_inbox_user}}
+ExecStart=npx ts-node-esm index.ts --port {{social_inbox_port}} --host {{social_inbox_host}}
+Restart=always
+RestartSec=3
+LimitNOFILE=4096
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/distributed_press/templates/social.distributed.press.service.j2
+++ b/ansible/roles/distributed_press/templates/social.distributed.press.service.j2
@@ -5,7 +5,7 @@ After=network-online.target
 # Environment="DEBUG=*"
 WorkingDirectory={{social_inbox_source}}
 User={{social_inbox_user}}
-ExecStart=npx ts-node-esm index.ts --port {{social_inbox_port}} --host {{social_inbox_host}}
+ExecStart=npx ts-node-esm index.ts --port {{social_inbox_port}} --host {{social_inbox_host}} --publicURL https://{{social_inbox_domain}}
 Restart=always
 RestartSec=3
 LimitNOFILE=4096


### PR DESCRIPTION
Adds a new `social_inbox_enabled` flag to deploy the distributed press social inbox along side the DP instance,

