### PR TITLE
feat: add cron job to restart the service every few days

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -38,6 +38,9 @@ all:
 ```
 # execute the Ansible playbook with user defined variables
 ansible-playbook distributed_press.yml -i inventory.yml
+
+# execute only the 'cron' related tasks of the Ansible playbook locally
+sudo ansible-playbook distributed_press.yml -i local_deploy.yml --tags cron
 ```
 
 ## Debugging Staging

--- a/ansible/local_deploy.yml
+++ b/ansible/local_deploy.yml
@@ -1,0 +1,11 @@
+---
+all:
+  vars:
+    distributed_press_domain: "localhost"
+    distributed_press_served_sites: []
+  children:
+    distributed_press:
+      hosts:
+        localhost:
+          ansible_connection: local
+          ansible_user: root

--- a/ansible/roles/distributed_press/tasks/main.yml
+++ b/ansible/roles/distributed_press/tasks/main.yml
@@ -88,6 +88,15 @@
     enabled: true
     name: "{{distributed_press_service_name}}"
 
+- name: "Add cron job to restart api.distributed.press service every few days"
+  cron:
+    name: "Restart api.distributed.press service"
+    day: "*/3"
+    job: "/bin/systemctl restart {{ distributed_press_service_name }}"
+  become: yes
+  tags:
+    - cron
+
 - name: "Install NGINX/Certbot"
   apt:
     pkg:

--- a/ansible/roles/distributed_press/templates/distributed_press_restart_cron.j2
+++ b/ansible/roles/distributed_press/templates/distributed_press_restart_cron.j2
@@ -1,0 +1,2 @@
+# Restart the api.distributed.press service every few days
+* * */3 * * /bin/systemctl restart {{distributed_press_service_name}}

--- a/ansible/roles/distributed_press/templates/distributed_press_restart_cron.j2
+++ b/ansible/roles/distributed_press/templates/distributed_press_restart_cron.j2
@@ -1,2 +1,0 @@
-# Restart the api.distributed.press service every few days
-* * */3 * * /bin/systemctl restart {{distributed_press_service_name}}


### PR DESCRIPTION
https://github.com/hyphacoop/distributed-press-organizing/issues/95
### Added cron job to restart api.distributed.press service every 3 days

```sh
sudo ansible-playbook distributed_press.yml -i local_deploy.yml --tags cron
```
![Screenshot 2023-10-10 at 11 39 03 PM](https://github.com/hyphacoop/api.distributed.press/assets/68826419/ac05963c-e8dc-46bc-9ce9-02dd87bd45ee)

```sh
sudo crontab -l
```
![Screenshot 2023-10-10 at 11 39 40 PM](https://github.com/hyphacoop/api.distributed.press/assets/68826419/f1a0758a-4453-4415-a515-581f7981606f)

