### PR TITLE
feat: always answer with the NS record in the authority section

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -70,7 +70,7 @@ async function apiBuilder (cfg: APIConfig): Promise<FastifyTypebox> {
   const store = new Store(cfg, db, protocols)
 
   server.log.info('Initializing DNS server')
-  const dns = await initDnsServer(cfg.dnsport, store.sites, server.log)
+  const dns = await initDnsServer(cfg.dnsport, store.sites, server.log, cfg.host)
 
   server.log.info('Done')
   await registerAuth(cfg, server, store)

--- a/dns/index.ts
+++ b/dns/index.ts
@@ -4,7 +4,7 @@ import { SiteConfigStore } from '../config/sites.js'
 
 const TTL = 604800 // 7 days ttl
 
-export async function initDnsServer (port: number, store: SiteConfigStore, logger?: FastifyBaseLogger): Promise<ReturnType<typeof dns2.createServer>> {
+export async function initDnsServer (port: number, store: SiteConfigStore, logger?: FastifyBaseLogger, host?: string = 'api.distributed.press'): Promise<ReturnType<typeof dns2.createServer>> {
   const server = dns2.createServer({
     udp: true,
     handle: (request, send, rinfo) => {
@@ -18,7 +18,7 @@ export async function initDnsServer (port: number, store: SiteConfigStore, logge
         type: dns2.Packet.TYPE.NS,
         class: dns2.Packet.CLASS.IN,
         ttl: TTL,
-        ns: 'api.distributed.press.'
+        ns: `${host}.`
       })
 
       const cleanedName = name.toLowerCase().replace('_dnslink.', '')

--- a/dns/index.ts
+++ b/dns/index.ts
@@ -12,6 +12,15 @@ export async function initDnsServer (port: number, store: SiteConfigStore, logge
       const [{ name }] = request.questions
       logger?.info(`[dns] ${rinfo.address}:${rinfo.port} asked for ${name}`)
 
+      // TODO: Pass server from config
+      response.authorities.push({
+        name,
+        type: dns2.Packet.TYPE.NS,
+        class: dns2.Packet.CLASS.IN,
+        ttl: TTL,
+        ns: 'api.distributed.press.'
+      })
+
       const cleanedName = name.toLowerCase().replace('_dnslink.', '')
       store.get(cleanedName)
         .then(({ links }) => {
@@ -33,6 +42,7 @@ export async function initDnsServer (port: number, store: SiteConfigStore, logge
               data: `dnslink=${links.hyper.dnslink}`
             })
           }
+
           send(response)
         })
         .catch((error) => {


### PR DESCRIPTION
if we don't do this, we're never going to see the resource record being found, because resolvers would recurse into the nameserver as the authority for this, even if intermediate nameservers know it.