### PR TITLE
fix: move ns to answers section

### DIFF
--- a/dns/index.test.ts
+++ b/dns/index.test.ts
@@ -42,7 +42,7 @@ test('basic dns resolve', async t => {
   const response = await dnsClient.query(`_dnslink.${site.domain}`, 'TXT')
   t.true(hasAnswer(response, 'ipns'), 'returned dns query has an ipns entry')
   t.true(hasAnswer(response, 'hyper'), 'returned dns query has a hyper entry')
-  t.is(response.answers.filter(ans => ans.type !== DNS.Packet.TYPE.TXT).length, 0, 'should not include any non-TXT entries')
+  t.is(response.answers.filter(ans => ![DNS.Packet.Type.NS, DNS.Packet.TYPE.TXT].includes(ans.type)).length, 0, 'should not include any non-TXT and non-NS entries')
 })
 
 test('dns should not resolve unknown domains', async t => {

--- a/dns/index.test.ts
+++ b/dns/index.test.ts
@@ -42,7 +42,7 @@ test('basic dns resolve', async t => {
   const response = await dnsClient.query(`_dnslink.${site.domain}`, 'TXT')
   t.true(hasAnswer(response, 'ipns'), 'returned dns query has an ipns entry')
   t.true(hasAnswer(response, 'hyper'), 'returned dns query has a hyper entry')
-  t.is(response.answers.filter(ans => ![DNS.Packet.Type.NS, DNS.Packet.TYPE.TXT].includes(ans.type)).length, 0, 'should not include any non-TXT and non-NS entries')
+  t.is(response.answers.filter(ans => ans.type !== DNS.Packet.TYPE.TXT && ans.type !== DNS.Packet.TYPE.NS).length, 0, 'should not include any non-TXT and non-NS entries')
 })
 
 test('dns should not resolve unknown domains', async t => {
@@ -50,5 +50,5 @@ test('dns should not resolve unknown domains', async t => {
   const port = dnsServer.addresses().udp?.port as number
   const dnsClient = makeDnsClient(port)
   const response = await dnsClient.query('_dnslink.unknown.com', 'TXT')
-  t.is(response.answers.length, 0, 'should not have any answers for unknown domains')
+  t.is(response.answers.filter(ans => ans.type === DNS.Packet.TYPE.TXT).length, 0, 'should not have any TXT answers for unknown domains')
 })

--- a/dns/index.ts
+++ b/dns/index.ts
@@ -12,8 +12,7 @@ export async function initDnsServer (port: number, store: SiteConfigStore, logge
       const [{ name }] = request.questions
       logger?.info(`[dns] ${rinfo.address}:${rinfo.port} asked for ${name}`)
 
-      // TODO: Pass server from config
-      response.authorities.push({
+      response.answers.push({
         name,
         type: dns2.Packet.TYPE.NS,
         class: dns2.Packet.CLASS.IN,

--- a/dns/index.ts
+++ b/dns/index.ts
@@ -12,6 +12,8 @@ export async function initDnsServer (port: number, store: SiteConfigStore, logge
       const [{ name }] = request.questions
       logger?.info(`[dns] ${rinfo.address}:${rinfo.port} asked for ${name}`)
 
+      // It will always answer with a NS record so new domains can be
+      // set up and checked.
       response.answers.push({
         name,
         type: dns2.Packet.TYPE.NS,


### PR DESCRIPTION
i was checking against other nameservers and realised the ns records belongs to the answers section, though it's a little weird to always respond with TXT and NS records independently of the actual question. but i think it'll require further fiddling with `@types/dns2`