### PR TITLE
fix: dynamically generate HTTP links in HTTP protocol sync method

### DIFF
--- a/protocols/http.ts
+++ b/protocols/http.ts
@@ -23,10 +23,13 @@ export class HTTPProtocol implements Protocol<Static<typeof HTTPProtocolFields>>
   }
 
   async sync (id: string, folderPath: string, options?: SyncOptions, ctx?: Ctx): Promise<Static<typeof HTTPProtocolFields>> {
-    // TODO(protocol): stub
+    // Generate the actual HTTP link based on the site ID (domain)
+    const httpLink = `http://${id}`
+
+    // Return the dynamically generated HTTP link
     return {
       enabled: true,
-      link: 'example-link'
+      link: httpLink
     }
   }
 

--- a/protocols/http.ts
+++ b/protocols/http.ts
@@ -24,7 +24,7 @@ export class HTTPProtocol implements Protocol<Static<typeof HTTPProtocolFields>>
 
   async sync (id: string, folderPath: string, options?: SyncOptions, ctx?: Ctx): Promise<Static<typeof HTTPProtocolFields>> {
     // Generate the actual HTTP link based on the site ID (domain)
-    const httpLink = `http://${id}`
+    const httpLink = `https://${id}`
 
     // Return the dynamically generated HTTP link
     return {


### PR DESCRIPTION
Removed the hardcoded placeholder `"example-link"`, ensuring the `http` protocol returns accurate and functional links for sites.