### PR TITLE
Fix peerId encoding

### DIFF
--- a/protocols/ipfs.ts
+++ b/protocols/ipfs.ts
@@ -38,7 +38,6 @@ import { IPFSProtocolFields } from '../api/schemas.js'
 import getPort from 'get-port'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { base36 } from 'multiformats/bases/base36'
-import { base58btc } from 'multiformats/bases/base58'
 
 // https://github.com/ipfs/helia/blob/main/packages/helia/src/utils/bootstrappers.ts
 const bootstrapConfig = {

--- a/protocols/ipfs.ts
+++ b/protocols/ipfs.ts
@@ -347,14 +347,11 @@ export class IPFSProtocol implements Protocol<Static<typeof IPFSProtocolFields>>
 
     // Verify the published value
     const peerId = await peerIdFromPrivateKey(privateKey)
-
-    // Convert peer ID to base36: peer IDs use base58 without multibase prefix
-    // Add the 'z' prefix that base58btc decoder expects
-    const peerIdBase58 = peerId.toString()
-    const peerIdWithPrefix = 'z' + peerIdBase58
-    const peerIdBytes = base58btc.decode(peerIdWithPrefix)
-    const peerIdBase36 = base36.encode(peerIdBytes)
-
+    
+    // Convert peer ID to base36 for IPNS using the multihash
+    const multihashBytes = peerId.toMultihash().bytes
+    const peerIdBase36 = base36.encode(multihashBytes)
+    
     try {
       // Use the public key directly instead of the IPNS name string
       const resolved = await this.ipns.resolve(privateKey.publicKey)


### PR DESCRIPTION
- Convert peer ID to base36 for IPNS using the multihash